### PR TITLE
Usar import en registration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "magento/framework": "*"
     },
     "type": "magento2-language",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "license": [
         "MIT"
     ],

--- a/registration.php
+++ b/registration.php
@@ -8,8 +8,12 @@
  * @author     Mugar (https://www.mugar.io/)
  */
 
-\Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::LANGUAGE,
+declare(strict_types=1);
+
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::LANGUAGE,
     'mugar_es_ar',
     __DIR__
 );


### PR DESCRIPTION
### Descripción
Se usa import para mejorar legibilidad del código.

### Issues relacionados (si fuera aplicable)
1. holamugar/language-es_ar#7: Usar import en Registration

